### PR TITLE
Simplify Container Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-FROM node:20-alpine \
-  AS build
+FROM node:20-alpine 
 
 ENV USER=appuser
 ENV UID=10001
@@ -42,8 +41,6 @@ RUN adduser \
 RUN apk update \
  && apk add --no-cache ca-certificates \
  && update-ca-certificates
-
-WORKDIR '/app'
 
 RUN npm install -g swagger-typescript-api@13.0.3 \
  && npx swagger-typescript-api --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-FROM mhart/alpine-node:16.4.2 \
+FROM node:20-alpine \
   AS build
 
 ENV USER=appuser
@@ -40,31 +40,14 @@ RUN adduser \
     "${USER}"
 
 RUN apk update \
- && apk add --no-cache ca-certificates python3 gcc g++ make linux-headers \
- && update-ca-certificates \
- && ln -sf python3 /usr/bin/python \
- && npm i -g pkg -D -S \
- && pkg -v
+ && apk add --no-cache ca-certificates \
+ && update-ca-certificates
 
 WORKDIR '/app'
 
-# npm install node-musl \
-#  && 
-
-RUN npm install swagger-typescript-api@12.0.3 \
+RUN npm install -g swagger-typescript-api@13.0.3 \
  && npx swagger-typescript-api --version
 
-RUN pkg -t node18-linuxstatic node_modules/.bin/swagger-typescript-api \
- && ./swagger-typescript-api --help
-
-FROM scratch \
-  AS image
-
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build /etc/group /etc/group
-COPY --from=build /app/swagger-typescript-api /sta
-
 USER appuser:appuser
-ENTRYPOINT ["/sta"]
+ENTRYPOINT ["sta"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,4 @@
 default: build
 
 build:
-#	docker build -t $(TARGET):`git describe --tags --always --dirty` .
-	docker build -t dummy .
+	docker build -t docker.sta:`git describe --tags --always --dirty` .


### PR DESCRIPTION
This PR introduces the following changes:

* use `node:20-alpine` as base image
* remove binary compilation of `swagger-typescript-api`
* update `swagger-typescript-api` to latest version `13.0.3`